### PR TITLE
Hotfix .push to null

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -100,6 +100,7 @@ function FreshTodo(title, body, status) {
 
 function getArrayFromStorage(){
   var todoArray = JSON.parse(localStorage.getItem("todoArray"));
+  todoArray === null ? todoArray = [] : null;
   return todoArray;
 }
 


### PR DESCRIPTION
After clearing local storage, JSON.parse mapped the array returned by getArrayFromStorage to null.

Hotfix adds ternary  <b>todoArray === null ? todoArray = [] : null; </b> to set todoArray to an empty array if it is null